### PR TITLE
cancel timeout watches to conserve resources

### DIFF
--- a/core/src/main/java/com/github/ladicek/oaken_ocean/core/timeout/ScheduledExecutorTimeoutWatcher.java
+++ b/core/src/main/java/com/github/ladicek/oaken_ocean/core/timeout/ScheduledExecutorTimeoutWatcher.java
@@ -1,6 +1,7 @@
 package com.github.ladicek.oaken_ocean.core.timeout;
 
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
 public class ScheduledExecutorTimeoutWatcher implements TimeoutWatcher {
@@ -11,7 +12,18 @@ public class ScheduledExecutorTimeoutWatcher implements TimeoutWatcher {
     }
 
     @Override
-    public void schedule(TimeoutExecution execution) {
-        executor.schedule(execution::timeoutAndInterrupt, execution.timeoutInMillis(), TimeUnit.MILLISECONDS);
+    public TimeoutWatch schedule(TimeoutExecution execution) {
+        ScheduledFuture<?> future = executor.schedule(execution::timeoutAndInterrupt, execution.timeoutInMillis(), TimeUnit.MILLISECONDS);
+        return new TimeoutWatch() {
+            @Override
+            public boolean isRunning() {
+                return !future.isDone();
+            }
+
+            @Override
+            public void cancel() {
+                future.cancel(true);
+            }
+        };
     }
 }

--- a/core/src/main/java/com/github/ladicek/oaken_ocean/core/timeout/TimeoutExecution.java
+++ b/core/src/main/java/com/github/ladicek/oaken_ocean/core/timeout/TimeoutExecution.java
@@ -23,12 +23,22 @@ final class TimeoutExecution {
         return timeoutInMillis;
     }
 
+    boolean isRunning() {
+        return state.get() == STATE_RUNNING;
+    }
+
+    boolean hasFinished() {
+        return state.get() == STATE_FINISHED;
+    }
+
     boolean hasTimedOut() {
         return state.get() == STATE_TIMED_OUT;
     }
 
-    void finish() {
-        state.compareAndSet(STATE_RUNNING, STATE_FINISHED);
+    void finish(Runnable ifFinished) {
+        if (state.compareAndSet(STATE_RUNNING, STATE_FINISHED)) {
+            ifFinished.run();
+        }
     }
 
     void timeoutAndInterrupt() {

--- a/core/src/main/java/com/github/ladicek/oaken_ocean/core/timeout/TimeoutWatch.java
+++ b/core/src/main/java/com/github/ladicek/oaken_ocean/core/timeout/TimeoutWatch.java
@@ -1,0 +1,7 @@
+package com.github.ladicek.oaken_ocean.core.timeout;
+
+interface TimeoutWatch {
+    boolean isRunning();
+
+    void cancel();
+}

--- a/core/src/main/java/com/github/ladicek/oaken_ocean/core/timeout/TimeoutWatcher.java
+++ b/core/src/main/java/com/github/ladicek/oaken_ocean/core/timeout/TimeoutWatcher.java
@@ -1,5 +1,5 @@
 package com.github.ladicek.oaken_ocean.core.timeout;
 
 public interface TimeoutWatcher {
-    void schedule(TimeoutExecution execution);
+    TimeoutWatch schedule(TimeoutExecution execution);
 }

--- a/core/src/test/java/com/github/ladicek/oaken_ocean/core/timeout/TimeoutExecutionTest.java
+++ b/core/src/test/java/com/github/ladicek/oaken_ocean/core/timeout/TimeoutExecutionTest.java
@@ -1,0 +1,64 @@
+package com.github.ladicek.oaken_ocean.core.timeout;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TimeoutExecutionTest {
+    private TimeoutExecution execution;
+
+    @Before
+    public void setUp() {
+        execution = new TimeoutExecution(Thread.currentThread(), 1000L);
+    }
+
+    @Test
+    public void initialState() {
+        assertThat(execution.isRunning()).isTrue();
+    }
+
+    @Test
+    public void timeoutValue() {
+        assertThat(execution.timeoutInMillis()).isEqualTo(1000L);
+    }
+
+    @Test
+    public void finish() {
+        AtomicBoolean flag = new AtomicBoolean(false);
+        execution.finish(() -> flag.set(true));
+        assertThat(execution.hasFinished()).isTrue();
+        assertThat(flag).isTrue();
+    }
+
+    @Test
+    public void timeout() {
+        execution.timeoutAndInterrupt();
+        assertThat(execution.hasTimedOut()).isTrue();
+        assertThat(Thread.interrupted()).isTrue(); // clear the current thread interruption status
+    }
+
+    @Test
+    public void timeoutAfterFinish() {
+        AtomicBoolean flag = new AtomicBoolean(false);
+        execution.finish(() -> flag.set(true));
+        execution.timeoutAndInterrupt();
+        assertThat(execution.hasFinished()).isTrue();
+        assertThat(execution.hasTimedOut()).isFalse();
+        assertThat(flag).isTrue();
+        assertThat(Thread.currentThread().isInterrupted()).isFalse();
+    }
+
+    @Test
+    public void finishAfterTimeout() {
+        AtomicBoolean flag = new AtomicBoolean(false);
+        execution.timeoutAndInterrupt();
+        execution.finish(() -> flag.set(true));
+        assertThat(execution.hasFinished()).isFalse();
+        assertThat(execution.hasTimedOut()).isTrue();
+        assertThat(flag).isFalse();
+        assertThat(Thread.interrupted()).isTrue(); // clear the current thread interruption status
+    }
+}

--- a/core/src/test/java/com/github/ladicek/oaken_ocean/core/timeout/TimeoutTest.java
+++ b/core/src/test/java/com/github/ladicek/oaken_ocean/core/timeout/TimeoutTest.java
@@ -15,7 +15,7 @@ public class TimeoutTest {
     private Barrier watcherTimeoutElapsedBarrier;
     private Barrier watcherExecutionInterruptedBarrier;
 
-    private TimeoutWatcher timeoutWatcher;
+    private TestTimeoutWatcher timeoutWatcher;
 
     @Before
     public void setUp() {
@@ -37,6 +37,7 @@ public class TimeoutTest {
         TestAction<String> action = TestAction.immediatelyReturning(() -> "foobar");
         TestThread<String> result = runOnTestThread(new Timeout<>(action, "test action", 1000, timeoutWatcher));
         assertThat(result.await()).isEqualTo("foobar");
+        assertThat(timeoutWatcher.timeoutWatchWasCancelled()).isTrue();
     }
 
     @Test
@@ -44,6 +45,7 @@ public class TimeoutTest {
         TestAction<Void> action = TestAction.immediatelyReturning(TestException::doThrow);
         TestThread<Void> result = runOnTestThread(new Timeout<>(action, "test action", 1000, timeoutWatcher));
         assertThatThrownBy(result::await).isExactlyInstanceOf(TestException.class);
+        assertThat(timeoutWatcher.timeoutWatchWasCancelled()).isTrue();
     }
 
     @Test
@@ -54,6 +56,7 @@ public class TimeoutTest {
         TestThread<String> result = runOnTestThread(new Timeout<>(action, "test action", 1000, timeoutWatcher));
         actionDelayBarrier.open();
         assertThat(result.await()).isEqualTo("foobar");
+        assertThat(timeoutWatcher.timeoutWatchWasCancelled()).isTrue();
     }
 
     @Test
@@ -67,6 +70,7 @@ public class TimeoutTest {
         assertThatThrownBy(result::await)
                 .isExactlyInstanceOf(TimeoutException.class)
                 .hasMessage("test action timed out");
+        assertThat(timeoutWatcher.timeoutWatchWasCancelled()).isFalse();
     }
 
     @Test
@@ -81,6 +85,7 @@ public class TimeoutTest {
         assertThatThrownBy(result::await)
                 .isExactlyInstanceOf(TimeoutException.class)
                 .hasMessage("test action timed out");
+        assertThat(timeoutWatcher.timeoutWatchWasCancelled()).isFalse();
     }
 
     @Test
@@ -93,6 +98,7 @@ public class TimeoutTest {
         actionStartBarrier.await();
         executingThread.interrupt();
         assertThatThrownBy(executingThread::await).isExactlyInstanceOf(InterruptedException.class);
+        assertThat(timeoutWatcher.timeoutWatchWasCancelled()).isTrue();
     }
 
     @Test
@@ -103,6 +109,7 @@ public class TimeoutTest {
         TestThread<Void> result = runOnTestThread(new Timeout<>(action, "test action", 1000, timeoutWatcher));
         actionDelayBarrier.open();
         assertThatThrownBy(result::await).isExactlyInstanceOf(TestException.class);
+        assertThat(timeoutWatcher.timeoutWatchWasCancelled()).isTrue();
     }
 
     @Test
@@ -116,6 +123,7 @@ public class TimeoutTest {
         assertThatThrownBy(result::await)
                 .isExactlyInstanceOf(TimeoutException.class)
                 .hasMessage("test action timed out");
+        assertThat(timeoutWatcher.timeoutWatchWasCancelled()).isFalse();
     }
 
     @Test
@@ -130,6 +138,7 @@ public class TimeoutTest {
         assertThatThrownBy(result::await)
                 .isExactlyInstanceOf(TimeoutException.class)
                 .hasMessage("test action timed out");
+        assertThat(timeoutWatcher.timeoutWatchWasCancelled()).isFalse();
     }
 
     @Test
@@ -142,5 +151,6 @@ public class TimeoutTest {
         actionStartBarrier.await();
         executingThread.interrupt();
         assertThatThrownBy(executingThread::await).isExactlyInstanceOf(InterruptedException.class);
+        assertThat(timeoutWatcher.timeoutWatchWasCancelled()).isTrue();
     }
 }


### PR DESCRIPTION
When an action that is guarded by a timeout successfully
completes, the timout watch used to keep running. That
is just a waste of time and resources.

This commit makes sure that when a timeout action finishes,
the timeout watch is cancelled. It also significantly improves
test coverage for timeouts.